### PR TITLE
chore: install Claude Code CLI via npm in all agent workflows

### DIFF
--- a/.github/workflows/cost-estimator-agent.yml
+++ b/.github/workflows/cost-estimator-agent.yml
@@ -24,8 +24,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+
       - name: Run Cost Estimator Agent via Claude Code CLI
         env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/development-agent.yml
+++ b/.github/workflows/development-agent.yml
@@ -23,8 +23,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+
       - name: Implement via Claude Sonnet
         env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
@@ -86,8 +92,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+
       - name: Implement via Claude Opus
         env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/documenter-agent.yml
+++ b/.github/workflows/documenter-agent.yml
@@ -24,8 +24,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+
       - name: Run Documenter Agent via Claude Code CLI
         env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/judging-agent.yml
+++ b/.github/workflows/judging-agent.yml
@@ -33,8 +33,14 @@ jobs:
           git fetch origin "impl/${ISSUE_NUMBER}-gpt53-codex" || true
           git fetch origin "impl/${ISSUE_NUMBER}-gpt54" || true
 
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+
       - name: Run Judging Agent via Claude Code CLI
         env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/planner-agent-trigger.yml
+++ b/.github/workflows/planner-agent-trigger.yml
@@ -20,8 +20,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+
       - name: Run Planner Agent via Claude Code CLI
         env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/pr-review-agent.yml
+++ b/.github/workflows/pr-review-agent.yml
@@ -26,9 +26,15 @@ jobs:
           echo "$CHANGED" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+
       - name: Run Review Agent via Claude Code CLI
         if: steps.changes.outputs.files != ''
         env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/release-agent.yml
+++ b/.github/workflows/release-agent.yml
@@ -24,8 +24,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+
       - name: Run Release Agent via Claude Code CLI
         env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/spec-edge-case-tester.yml
+++ b/.github/workflows/spec-edge-case-tester.yml
@@ -20,8 +20,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+
       - name: Run Spec Edge Case Tester via Claude Code CLI
         env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
All workflows now:
- Run on ubuntu-latest (GitHub-hosted runner)
- Install @anthropic-ai/claude-code via npm
- Use ANTHROPIC_API_KEY secret for authentication

Requires adding ANTHROPIC_API_KEY to repo secrets.