### PR TITLE
Implement Python Proof-of-Deploy prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MaatProof is a Layer 1 blockchain for **Agentic CI/CD (ACI/ACD)**. It replaces t
 
 Every deployment decision produces a `ReasoningProof` — a hash-chained, HMAC-signed artifact that answers *"Why did this deploy at 2 am?"* with a cryptographically verifiable answer, not a stale log entry.
 
-The protocol stack is built in **Rust** (consensus engine, AVM, DRE, VRP, ADA), **Node.js** (orchestrator, GitHub integrations, SDK), and **Solidity** (deployment contracts, tokenomics, governance).
+The executable reference prototype is now implemented in **Python** for local replay and Google Colab experimentation. Future production hardening still targets **Rust/WASM** for AVM, VRP, DRE, and consensus components, with **Solidity** for deployment contracts, tokenomics, and governance.
 
 ## What MaatProof Does
 
@@ -34,9 +34,32 @@ The protocol stack is built in **Rust** (consensus engine, AVM, DRE, VRP, ADA), 
 
 ## Status
 
-🚧 **Spec Phase** — Architecture defined, agent pipeline operational, core implementation in progress.
+🚧 **Reference Prototype** — Python certificate checker, signed evidence bundles, VRP derivations, validator quorum, and JSONL ledger are available for local experimentation.
 
 📄 **[Read the full MaatProof Whitepaper →](https://www.overleaf.com/read/hvsvqyvzfmhf#89e3b9)**
+
+## Try it in Google Colab
+
+Run the end-to-end Proof-of-Deploy example in [`examples/proof_of_deploy_colab.ipynb`](examples/proof_of_deploy_colab.ipynb). The notebook builds a certificate `C = <P, E, pi, A>`, checks `WF(P)`, `Auth(E)`, `CheckR(pi, P, E)`, and `Quorum(A)`, appends an accepted certificate to a local JSONL ledger, then demonstrates structured failures for missing scan evidence, stale human attestation, wrong environment binding, invalid derivation, and insufficient quorum.
+
+Local setup:
+
+```bash
+pip install -e .
+python -m pytest tests -v
+```
+
+Python module mapping:
+
+| Formal object | Python module |
+|---|---|
+| `P` deployment policy and `WF(P)` | `maatproof.policy` |
+| `E` evidence bundle and `Auth(E)` | `maatproof.evidence` |
+| `pi` derivation and `CheckR(pi, P, E)` | `maatproof.vrp` |
+| `A` validator attestations and `Quorum(A)` | `maatproof.pod` |
+| `C = <P,E,pi,A>` and `Accept(C)` | `maatproof.certificate` |
+| Finalized certificate log | `maatproof.ledger` |
+| AVM boundary trace-to-evidence binding | `maatproof.avm` |
 
 ---
 

--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -5,11 +5,11 @@
 ```mermaid
 flowchart LR
     A["🤖 Agent\n(signs + stakes)"] --> B["📜 Deployment\nContract\n(Solidity)"]
-    B --> C["⚙️ AVM\n(Rust/WASM)"]
-    C --> D["🧠 DRE\n(Rust)"]
-    D --> E["✅ VRP\n(Rust)"]
-    E --> F["🔐 ADA\n(Rust)"]
-    F --> G["🗳️ PoD Consensus\n(Rust/gRPC)"]
+    B --> C["⚙️ AVM Boundary\n(Python prototype,\nfuture Rust/WASM)"]
+    C --> D["🧠 Evidence Bundle\n(Python canon + HMAC)"]
+    D --> E["✅ VRP\n(Python CheckR,\nfuture Rust)"]
+    E --> F["🔐 Certificate Checker\nAccept(C)"]
+    F --> G["🗳️ PoD Consensus\n(Python local replay,\nfuture Rust/gRPC)"]
     G --> H["⛓️ MaatProof\nChain"]
     H --> I["🚀 Production\n+ Runtime Guard"]
     F -.->|"if policy\nrequires it"| J["👤 Human\nApproval\n(policy gate)"]
@@ -18,11 +18,11 @@ flowchart LR
 
 1. Agent proposes deployment with signed identity and staked $MAAT
 2. Deployment Contract encodes on-chain policy rules
-3. AVM executes and records reasoning trace in WASM sandbox (Rust)
-4. DRE builds canonical PromptBundle, runs N-of-M model committee (Rust)
-5. VRP compiles admissible reasoning into a Merkleized DAG (Rust)
-6. ADA verifies all 7 conditions and emits signed authorization (Rust)
-7. Proof-of-Reasoning Consensus: validators replay and attest (Rust/gRPC)
+3. AVM boundary captures externally observable tool traces as typed evidence
+4. Evidence bundle canonicalization signs and authenticates `E`
+5. VRP checks admissible derivation `pi` with deterministic Python `CheckR`
+6. Certificate checker evaluates `Accept(C) = WF(P) && Auth(E) && CheckR(pi,P,E) && Quorum(A)`
+7. Proof-of-Deploy Consensus: validators replay and attest locally in Python, with Rust/gRPC planned for production
 8. Finalized block written on-chain with full audit record
 9. Production Gate unlocks; Runtime Guard monitors with auto-rollback
 
@@ -76,7 +76,32 @@ agent:planner → agent:spec-edge-test → spec:passed
 
 ## Components
 
-**Tech stack:** Rust (AVM, DRE, VRP, consensus engine, cryptographic primitives) · Node.js (orchestrator agent, integrations, SDK) · Solidity (on-chain contracts) · WASM (sandbox execution)
+**Tech stack:** Python reference prototype (`maatproof.policy`, `maatproof.evidence`, `maatproof.vrp`, `maatproof.pod`, `maatproof.certificate`, `maatproof.ledger`, `maatproof.avm`) · Rust/WASM planned for production AVM/VRP/DRE/consensus hardening · Node.js planned for orchestrator integrations · Solidity for on-chain contracts and incentives
+
+## Python Proof-of-Deploy Reference Prototype
+
+The repository now includes an executable Python implementation of the formal certificate model from the Proof-Carrying Deployment paper:
+
+```mermaid
+flowchart LR
+    P["P: DeploymentPolicy\nWF(P)"] --> C["C: DeploymentCertificate\nAccept(C)"]
+    E["E: EvidenceBundle\nAuth(E)"] --> C
+    PI["pi: ProofDerivation\nCheckR(pi,P,E)"] --> C
+    A["A: ValidatorAttestation[]\nQuorum(A)"] --> C
+    C --> L["JsonlDeploymentLedger\nfinalized certificate log"]
+```
+
+| Formal term | Python implementation | Responsibility |
+|---|---|---|
+| `P` | `maatproof.policy.DeploymentPolicy` | Policy predicates, environment binding, optional human-attestation rule, and `WF(P)` |
+| `E` | `maatproof.evidence.EvidenceBundle` | Signed evidence objects, canonical ordering, freshness/dependency checks, and `Auth(E)` |
+| `pi` | `maatproof.vrp.ProofDerivation` | Typed admissible proof steps and deterministic `CheckR(pi, P, E)` |
+| `A` | `maatproof.pod.ValidatorAttestation` | Validator signatures, accept/reject/dispute decisions, and quorum finality |
+| `C` | `maatproof.certificate.DeploymentCertificate` | Certificate digest and top-level `Accept(C)` report |
+| Ledger | `maatproof.ledger.JsonlDeploymentLedger` | Append-only local record and replay verification |
+| AVM boundary | `maatproof.avm.DeploymentTrace` | Trace-to-evidence conversion without private model chain-of-thought |
+
+The prototype intentionally uses HMAC-SHA256 to keep the Colab and test environment dependency-free. Ed25519 and post-quantum signature providers remain production-hardening adapters rather than certificate-validity changes.
 
 ### 1. Agent
 - Proposes deployment with signed identity (`did:maat:agent:<hex>`)

--- a/docs/08-roadmap.md
+++ b/docs/08-roadmap.md
@@ -6,8 +6,9 @@ MaatProof is developed under the assumption that **full ACD is the operating mod
 the beginning**. The roadmap sequences the proof primitives needed to make autonomous
 deployment safe — it does not treat autonomous production deploy as a speculative endpoint.
 
-Sequence: canonical bundles → DRE normalization → VRP checkers → validator replay →
-runtime guards → staking/slashing → ecosystem integrations → optional ZK upgrades
+Immediate sequence: Python local certificate checker → signed evidence bundle generation and canonicalization → local validator replay/quorum simulator → JSONL deployment ledger prototype → incentive simulation → post-quantum signature experiment.
+
+Production-hardening sequence: canonical bundles → DRE normalization → Rust/WASM VRP checkers → validator replay → runtime guards → staking/slashing → ecosystem integrations → optional ZK upgrades.
 
 ---
 
@@ -20,8 +21,9 @@ gantt
     axisFormat  %b %Y
 
     section Phase 1 Genesis
-    PromptBundle + EvidenceBundle (Rust)  :p1a, 2025-01, 3M
-    AVM v0.1 trace recording (Rust/WASM) :p1b, 2025-01, 3M
+    Python Proof-of-Deploy prototype      :p1p, 2025-01, 1M
+    PromptBundle + EvidenceBundle (Rust)  :p1a, after p1p, 3M
+    AVM v0.1 trace recording (Rust/WASM) :p1b, after p1p, 3M
     Basic Deployment Contracts (Solidity) :p1c, 2025-02, 2M
     Node.js SDK alpha                     :p1d, 2025-02, 2M
 
@@ -66,6 +68,7 @@ gantt
 
 | Deliverable | Tech | Description |
 |---|---|---|
+| Proof-of-Deploy prototype | Python | Local certificate checker for `C = <P,E,pi,A>`, signed evidence, VRP derivations, validator quorum, JSONL ledger, and Colab walkthrough |
 | PromptBundle (content-addressed) | Rust | Canonical serialization of all deployment context |
 | EvidenceBundle | Rust | Content-addressed artifact collection |
 | AVM v0.1 | Rust / WASM | Trace recording and basic WASM sandbox replay |

--- a/examples/proof_of_deploy_colab.ipynb
+++ b/examples/proof_of_deploy_colab.ipynb
@@ -1,0 +1,231 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# MaatProof Proof-of-Deploy Colab\n",
+        "\n",
+        "This notebook runs the Python reference implementation for the formal certificate model `C = <P, E, pi, A>` and the acceptance rule `Accept(C) = WF(P) && Auth(E) && CheckR(pi, P, E) && Quorum(A)`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# In Google Colab, run this after cloning the repository:\n",
+        "# !git clone https://github.com/dngoins/MaatProof.git\n",
+        "# %cd MaatProof\n",
+        "# !pip install -e .\n",
+        "\n",
+        "# In a local checkout, install with:\n",
+        "# !pip install -e ."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from pathlib import Path\n",
+        "\n",
+        "from maatproof import (\n",
+        "    CertificateChecker,\n",
+        "    DeploymentCertificate,\n",
+        "    DeploymentPolicy,\n",
+        "    DeploymentRequest,\n",
+        "    EvidenceBundle,\n",
+        "    JsonlDeploymentLedger,\n",
+        "    PolicyPredicate,\n",
+        "    ProofDerivation,\n",
+        "    ProofStep,\n",
+        "    QuorumRule,\n",
+        "    ValidatorAttestation,\n",
+        "    signed_evidence,\n",
+        "    simulate_validators,\n",
+        ")\n",
+        "\n",
+        "EVIDENCE_SECRET = b'evidence-secret'\n",
+        "VALIDATORS = {\n",
+        "    'validator-a': b'validator-a-secret',\n",
+        "    'validator-b': b'validator-b-secret',\n",
+        "    'validator-c': b'validator-c-secret',\n",
+        "}\n",
+        "NOW = 1_700_000_100.0"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def deployment_request(environment='production'):\n",
+        "    return DeploymentRequest(\n",
+        "        deployment_id='deploy-123',\n",
+        "        service='checkout',\n",
+        "        environment=environment,\n",
+        "        commit_sha='abc123',\n",
+        "        artifact_hash='sha256:artifact',\n",
+        "        requested_by='agent:planner',\n",
+        "    )\n",
+        "\n",
+        "\n",
+        "def deployment_policy(environment='production'):\n",
+        "    return DeploymentPolicy(\n",
+        "        policy_id='checkout-prod',\n",
+        "        version=1,\n",
+        "        environment=environment,\n",
+        "        freshness_seconds={'human_attestation': 3600, 'scan_report': 3600},\n",
+        "        predicates=[\n",
+        "            PolicyPredicate('test_passed', {'suite': 'unit'}),\n",
+        "            PolicyPredicate('vuln_count', {'severity': 'critical', 'operator': '<=', 'threshold': 0}),\n",
+        "            PolicyPredicate('environment_matches', {'target': environment}),\n",
+        "            PolicyPredicate('rollback_defined', {'service': 'checkout'}),\n",
+        "            PolicyPredicate('human_attested', {'role': 'release-manager'}),\n",
+        "        ],\n",
+        "    )\n",
+        "\n",
+        "\n",
+        "def evidence_bundle(request, include_scan=True, human_timestamp=NOW):\n",
+        "    objects = [\n",
+        "        signed_evidence('commit', 'commit_snapshot', {'deployment_id': request.deployment_id, 'commit_sha': request.commit_sha}, 'git', NOW, EVIDENCE_SECRET),\n",
+        "        signed_evidence('artifact', 'build_artifact', {'deployment_id': request.deployment_id, 'artifact_hash': request.artifact_hash}, 'builder', NOW, EVIDENCE_SECRET, dependencies=['commit']),\n",
+        "        signed_evidence('test', 'test_result', {'deployment_id': request.deployment_id, 'suite': 'unit', 'passed': True}, 'pytest', NOW, EVIDENCE_SECRET, dependencies=['artifact']),\n",
+        "        signed_evidence('env', 'environment_descriptor', {'deployment_id': request.deployment_id, 'environment': request.environment}, 'cluster', NOW, EVIDENCE_SECRET),\n",
+        "        signed_evidence('rollback', 'rollback_spec', {'deployment_id': request.deployment_id, 'service': request.service, 'rollback_plan': 'restore previous image'}, 'deploy-plan', NOW, EVIDENCE_SECRET),\n",
+        "        signed_evidence('human', 'human_attestation', {'deployment_id': request.deployment_id, 'role': 'release-manager', 'approved': True}, 'approvals', human_timestamp, EVIDENCE_SECRET),\n",
+        "    ]\n",
+        "    if include_scan:\n",
+        "        objects.append(signed_evidence('scan', 'scan_report', {'deployment_id': request.deployment_id, 'vulnerabilities': {'critical': 0, 'high': 1}}, 'scanner', NOW, EVIDENCE_SECRET, dependencies=['artifact']))\n",
+        "    return EvidenceBundle(objects)\n",
+        "\n",
+        "\n",
+        "def derivation(request, bad_rule=False):\n",
+        "    first_rule = 'TRUST_ME' if bad_rule else 'TEST_PASS'\n",
+        "    return ProofDerivation(\n",
+        "        final_conclusion=f'deploy_authorized:{request.deployment_id}',\n",
+        "        steps=[\n",
+        "            ProofStep('test-pass', first_rule, 'test_passed:unit', ['test']),\n",
+        "            ProofStep('scan-ok', 'VULN_OK', 'vuln_count:critical<=0', ['scan']),\n",
+        "            ProofStep('env-ok', 'ENVIRONMENT_MATCH', 'environment_matches', ['env']),\n",
+        "            ProofStep('rollback-ok', 'ROLLBACK_READY', 'rollback_defined', ['rollback']),\n",
+        "            ProofStep('human-ok', 'HUMAN_ATTESTED', 'human_attested:release-manager', ['human']),\n",
+        "            ProofStep('policy', 'POLICY_SATISFIED', 'policy_satisfied', premises=['test-pass', 'scan-ok', 'env-ok', 'rollback-ok', 'human-ok']),\n",
+        "            ProofStep('deploy', 'DEPLOY_AUTH', f'deploy_authorized:{request.deployment_id}', premises=['policy']),\n",
+        "        ],\n",
+        "    )\n",
+        "\n",
+        "\n",
+        "def certificate(include_scan=True, environment='production', policy_environment='production', human_timestamp=NOW, bad_rule=False):\n",
+        "    request = deployment_request(environment)\n",
+        "    return DeploymentCertificate(\n",
+        "        request=request,\n",
+        "        policy=deployment_policy(policy_environment),\n",
+        "        evidence=evidence_bundle(request, include_scan=include_scan, human_timestamp=human_timestamp),\n",
+        "        proof=derivation(request, bad_rule=bad_rule),\n",
+        "    )\n",
+        "\n",
+        "\n",
+        "def summarize(report):\n",
+        "    return {\n",
+        "        'accepted': report.accepted,\n",
+        "        'WF(P)': report.wf_policy,\n",
+        "        'Auth(E)': report.auth_evidence,\n",
+        "        'CheckR': report.check_proof,\n",
+        "        'Quorum(A)': report.quorum,\n",
+        "        'failures': [failure.code for failure in report.failures],\n",
+        "    }"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Happy path: valid certificate and finalized deployment"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "valid = certificate()\n",
+        "pre_quorum_checker = CertificateChecker(EVIDENCE_SECRET, now=NOW)\n",
+        "valid.attestations = simulate_validators(valid, pre_quorum_checker, VALIDATORS, timestamp=NOW)\n",
+        "\n",
+        "checker = CertificateChecker(EVIDENCE_SECRET, VALIDATORS, QuorumRule.majority(), now=NOW)\n",
+        "report = checker.accept(valid)\n",
+        "summarize(report)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "ledger = JsonlDeploymentLedger(Path('/tmp/maatproof-deployments.jsonl'))\n",
+        "entry = ledger.append(valid, report, timestamp=NOW)\n",
+        "entry.to_dict()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Failure scenarios"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "cases = {}\n",
+        "\n",
+        "missing_scan = certificate(include_scan=False)\n",
+        "cases['missing scan evidence'] = checker.accept(missing_scan)\n",
+        "\n",
+        "stale_human = certificate(human_timestamp=NOW - 7200)\n",
+        "cases['stale human attestation'] = checker.accept(stale_human)\n",
+        "\n",
+        "wrong_environment = certificate(environment='staging', policy_environment='production')\n",
+        "cases['wrong environment binding'] = checker.accept(wrong_environment)\n",
+        "\n",
+        "invalid_derivation = certificate(bad_rule=True)\n",
+        "cases['invalid derivation step'] = checker.accept(invalid_derivation)\n",
+        "\n",
+        "insufficient_quorum = certificate()\n",
+        "digest = insufficient_quorum.digest()\n",
+        "insufficient_quorum.attestations = [\n",
+        "    ValidatorAttestation('validator-a', 'accept', digest, NOW).sign(VALIDATORS['validator-a']),\n",
+        "    ValidatorAttestation('validator-b', 'reject', digest, NOW).sign(VALIDATORS['validator-b']),\n",
+        "]\n",
+        "cases['insufficient quorum'] = checker.accept(insufficient_quorum)\n",
+        "\n",
+        "{name: summarize(result) for name, result in cases.items()}"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "pygments_lexer": "ipython3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/maatproof/__init__.py
+++ b/maatproof/__init__.py
@@ -17,6 +17,16 @@ Public API::
 """
 
 from .chain import ReasoningChain
+from .avm import AgentAction, DeploymentTrace, ToolTrace
+from .certificate import (
+    AcceptanceFailure,
+    AcceptanceReport,
+    CertificateChecker,
+    CertificateDigest,
+    DeploymentCertificate,
+    DeploymentRequest,
+)
+from .evidence import EvidenceAuthReport, EvidenceBundle, EvidenceObject, signed_evidence
 from .exceptions import (
     GateFailureError,
     HumanApprovalRequiredError,
@@ -31,9 +41,19 @@ from .layers.deterministic import (
     GateResult,
     GateStatus,
 )
+from .ledger import JsonlDeploymentLedger, LedgerEntry
 from .orchestrator import AuditEntry, OrchestratingAgent, PipelineEvent
 from .pipeline import ACDPipeline, ACIPipeline, PipelineConfig
+from .pod import (
+    FinalityReport,
+    QuorumRule,
+    ValidatorAttestation,
+    quorum_finality,
+    simulate_validators,
+)
+from .policy import DeploymentPolicy, PolicyCheckReport, PolicyPredicate
 from .proof import ProofBuilder, ProofVerifier, ReasoningProof, ReasoningStep
+from .vrp import ProofDerivation, ProofStep, VrpCheckReport, check_derivation
 
 __version__ = "0.1.0"
 
@@ -63,6 +83,37 @@ __all__ = [
     "ACIPipeline",
     "ACDPipeline",
     "PipelineConfig",
+    # Proof-of-Deploy certificate core
+    "AcceptanceFailure",
+    "AcceptanceReport",
+    "CertificateChecker",
+    "CertificateDigest",
+    "DeploymentCertificate",
+    "DeploymentRequest",
+    # Policy and evidence
+    "DeploymentPolicy",
+    "PolicyCheckReport",
+    "PolicyPredicate",
+    "EvidenceAuthReport",
+    "EvidenceBundle",
+    "EvidenceObject",
+    "signed_evidence",
+    # VRP and finality
+    "ProofDerivation",
+    "ProofStep",
+    "VrpCheckReport",
+    "check_derivation",
+    "FinalityReport",
+    "QuorumRule",
+    "ValidatorAttestation",
+    "quorum_finality",
+    "simulate_validators",
+    "JsonlDeploymentLedger",
+    "LedgerEntry",
+    # AVM boundary
+    "AgentAction",
+    "DeploymentTrace",
+    "ToolTrace",
     # Exceptions
     "MaatProofError",
     "ProofVerificationError",

--- a/maatproof/avm.py
+++ b/maatproof/avm.py
@@ -1,0 +1,84 @@
+"""Python AVM-boundary trace model for externally observable agent actions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+from .evidence import EvidenceBundle, signed_evidence
+
+
+@dataclass(frozen=True)
+class ToolTrace:
+    """Externally observable tool output captured by the AVM boundary."""
+
+    tool_name: str
+    output_type: str
+    output: Dict[str, Any]
+    timestamp: float
+    source: str = "avm"
+    dependencies: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "tool_name": self.tool_name,
+            "output_type": self.output_type,
+            "output": self.output,
+            "timestamp": self.timestamp,
+            "source": self.source,
+            "dependencies": list(self.dependencies),
+        }
+
+
+@dataclass(frozen=True)
+class AgentAction:
+    """Agent-visible action without private model chain-of-thought."""
+
+    action_id: str
+    action_type: str
+    deployment_id: str
+    timestamp: float
+    summary: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "action_id": self.action_id,
+            "action_type": self.action_type,
+            "deployment_id": self.deployment_id,
+            "timestamp": self.timestamp,
+            "summary": self.summary,
+        }
+
+
+@dataclass
+class DeploymentTrace:
+    """Trace-to-evidence binding for one deployment request."""
+
+    deployment_id: str
+    actions: List[AgentAction] = field(default_factory=list)
+    tools: List[ToolTrace] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "deployment_id": self.deployment_id,
+            "actions": [action.to_dict() for action in self.actions],
+            "tools": [tool.to_dict() for tool in self.tools],
+        }
+
+    def to_evidence_bundle(self, secret_key: bytes) -> EvidenceBundle:
+        evidence = []
+        for index, tool in enumerate(self.tools):
+            value = dict(tool.output)
+            value.setdefault("deployment_id", self.deployment_id)
+            evidence.append(
+                signed_evidence(
+                    evidence_id=f"{self.deployment_id}:{index}:{tool.output_type}",
+                    evidence_type=tool.output_type,
+                    value=value,
+                    source=f"avm:{tool.tool_name}",
+                    timestamp=tool.timestamp,
+                    secret_key=secret_key,
+                    dependencies=tool.dependencies,
+                )
+            )
+        return EvidenceBundle(evidence)

--- a/maatproof/canonical.py
+++ b/maatproof/canonical.py
@@ -1,0 +1,42 @@
+"""Canonical serialization, hashing, and HMAC helpers for Proof-of-Deploy."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from typing import Any, Mapping
+
+
+def canonical_dumps(value: Any) -> str:
+    """Return deterministic JSON for hashing and signing."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def canonical_hash(value: Any) -> str:
+    """Return a SHA-256 hex digest over canonical JSON."""
+    return hashlib.sha256(canonical_dumps(value).encode("utf-8")).hexdigest()
+
+
+def hmac_sign(secret_key: bytes, value: Any) -> str:
+    """Return an HMAC-SHA256 signature over canonical JSON."""
+    if not isinstance(secret_key, bytes):
+        raise TypeError("secret_key must be bytes")
+    if not secret_key:
+        raise ValueError("secret_key must not be empty")
+    return hmac.new(
+        secret_key,
+        canonical_dumps(value).encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def hmac_verify(secret_key: bytes, value: Any, signature: str) -> bool:
+    """Verify an HMAC-SHA256 signature over canonical JSON."""
+    expected = hmac_sign(secret_key, value)
+    return hmac.compare_digest(expected, signature)
+
+
+def without_keys(value: Mapping[str, Any], *keys: str) -> dict:
+    """Return a copy of *value* without the named keys."""
+    return {k: v for k, v in value.items() if k not in set(keys)}

--- a/maatproof/certificate.py
+++ b/maatproof/certificate.py
@@ -1,0 +1,240 @@
+"""Deployment certificate model and top-level ``Accept(C)`` checker."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from .canonical import canonical_hash
+from .evidence import EvidenceBundle
+from .pod import FinalityReport, QuorumRule, ValidatorAttestation, quorum_finality
+from .policy import DeploymentPolicy
+from .vrp import ProofDerivation, check_derivation
+
+
+@dataclass(frozen=True)
+class DeploymentRequest:
+    """The exact deployment target authorized by a certificate."""
+
+    deployment_id: str
+    service: str
+    environment: str
+    commit_sha: str
+    artifact_hash: str
+    requested_by: str
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            "deployment_id": self.deployment_id,
+            "service": self.service,
+            "environment": self.environment,
+            "commit_sha": self.commit_sha,
+            "artifact_hash": self.artifact_hash,
+            "requested_by": self.requested_by,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, str]) -> "DeploymentRequest":
+        return cls(**data)
+
+
+@dataclass(frozen=True)
+class CertificateDigest:
+    """Named digest values for certificate sub-roots."""
+
+    certificate: str
+    policy: str
+    evidence: str
+    proof: str
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            "certificate": self.certificate,
+            "policy": self.policy,
+            "evidence": self.evidence,
+            "proof": self.proof,
+        }
+
+
+@dataclass
+class AcceptanceFailure:
+    """Structured certificate rejection reason."""
+
+    component: str
+    code: str
+    message: str = ""
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            "component": self.component,
+            "code": self.code,
+            "message": self.message,
+        }
+
+
+@dataclass
+class AcceptanceReport:
+    """Structured result for ``Accept(C)``."""
+
+    accepted: bool
+    certificate_digest: str
+    wf_policy: bool
+    auth_evidence: bool
+    check_proof: bool
+    quorum: bool
+    failures: List[AcceptanceFailure] = field(default_factory=list)
+    evidence_root: str = ""
+    proof_root: str = ""
+    policy_root: str = ""
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "accepted": self.accepted,
+            "certificate_digest": self.certificate_digest,
+            "wf_policy": self.wf_policy,
+            "auth_evidence": self.auth_evidence,
+            "check_proof": self.check_proof,
+            "quorum": self.quorum,
+            "evidence_root": self.evidence_root,
+            "proof_root": self.proof_root,
+            "policy_root": self.policy_root,
+            "failures": [failure.to_dict() for failure in self.failures],
+        }
+
+
+@dataclass
+class DeploymentCertificate:
+    """Proof-carrying deployment certificate ``C = <P, E, pi, A>``."""
+
+    request: DeploymentRequest
+    policy: DeploymentPolicy
+    evidence: EvidenceBundle
+    proof: ProofDerivation
+    attestations: List[ValidatorAttestation] = field(default_factory=list)
+
+    def body(self) -> Dict[str, object]:
+        return {
+            "request": self.request.to_dict(),
+            "policy": self.policy.to_dict(),
+            "evidence": self.evidence.to_dict(),
+            "proof": self.proof.to_dict(),
+        }
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            **self.body(),
+            "attestations": [att.to_dict() for att in self.attestations],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "DeploymentCertificate":
+        return cls(
+            request=DeploymentRequest.from_dict(data["request"]),  # type: ignore[arg-type]
+            policy=DeploymentPolicy.from_dict(data["policy"]),  # type: ignore[arg-type]
+            evidence=EvidenceBundle.from_dict(data["evidence"]),  # type: ignore[arg-type]
+            proof=ProofDerivation.from_dict(data["proof"]),  # type: ignore[arg-type]
+            attestations=[
+                ValidatorAttestation.from_dict(att)
+                for att in data.get("attestations", [])  # type: ignore[union-attr]
+            ],
+        )
+
+    def digest(self) -> str:
+        """Digest signed by validators; attestations are deliberately excluded."""
+        return canonical_hash(self.body())
+
+    def digests(self) -> CertificateDigest:
+        return CertificateDigest(
+            certificate=self.digest(),
+            policy=canonical_hash(self.policy.to_dict()),
+            evidence=self.evidence.root(),
+            proof=canonical_hash(self.proof.to_dict()),
+        )
+
+
+class CertificateChecker:
+    """Top-level checker for ``WF(P) && Auth(E) && CheckR(pi,P,E) && Quorum(A)``."""
+
+    def __init__(
+        self,
+        evidence_secret_key: bytes,
+        validator_secret_keys: Optional[Dict[str, bytes]] = None,
+        quorum_rule: Optional[QuorumRule] = None,
+        now: Optional[float] = None,
+    ) -> None:
+        self.evidence_secret_key = evidence_secret_key
+        self.validator_secret_keys = validator_secret_keys or {}
+        self.quorum_rule = quorum_rule or QuorumRule.majority()
+        self.now = now
+
+    def accept(self, certificate: DeploymentCertificate) -> AcceptanceReport:
+        return self._accept(certificate, include_quorum=True)
+
+    def accept_without_quorum(
+        self, certificate: DeploymentCertificate
+    ) -> AcceptanceReport:
+        return self._accept(certificate, include_quorum=False)
+
+    def _accept(
+        self,
+        certificate: DeploymentCertificate,
+        include_quorum: bool,
+    ) -> AcceptanceReport:
+        failures: List[AcceptanceFailure] = []
+        digests = certificate.digests()
+
+        policy_report = certificate.policy.well_formed()
+        failures.extend(
+            AcceptanceFailure("WF(P)", code) for code in policy_report.failures
+        )
+
+        evidence_report = certificate.evidence.authenticate(
+            certificate.policy,
+            certificate.request,
+            self.evidence_secret_key,
+            now=self.now,
+        )
+        failures.extend(
+            AcceptanceFailure("Auth(E)", code)
+            for code in evidence_report.failures
+        )
+
+        proof_report = check_derivation(
+            certificate.proof,
+            certificate.policy,
+            certificate.evidence,
+            certificate.request,
+        )
+        failures.extend(
+            AcceptanceFailure("CheckR", code) for code in proof_report.failures
+        )
+
+        finality = FinalityReport(finalized=True)
+        if include_quorum:
+            finality = quorum_finality(
+                certificate.attestations,
+                digests.certificate,
+                self.validator_secret_keys,
+                self.quorum_rule,
+            )
+            failures.extend(
+                AcceptanceFailure("Quorum(A)", code)
+                for code in finality.failures
+            )
+
+        wf_policy = policy_report.well_formed
+        auth_evidence = evidence_report.authenticated
+        check_proof = proof_report.valid
+        quorum = finality.finalized
+        return AcceptanceReport(
+            accepted=wf_policy and auth_evidence and check_proof and quorum,
+            certificate_digest=digests.certificate,
+            wf_policy=wf_policy,
+            auth_evidence=auth_evidence,
+            check_proof=check_proof,
+            quorum=quorum,
+            failures=failures,
+            evidence_root=digests.evidence,
+            proof_root=digests.proof,
+            policy_root=digests.policy,
+        )

--- a/maatproof/evidence.py
+++ b/maatproof/evidence.py
@@ -1,0 +1,281 @@
+"""Evidence objects, canonical evidence bundles, and ``Auth(E)`` checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional
+
+from .canonical import canonical_hash, hmac_sign, hmac_verify
+
+
+@dataclass
+class EvidenceObject:
+    """A signed external fact used by a deployment certificate."""
+
+    evidence_id: str
+    evidence_type: str
+    value: Dict[str, Any]
+    source: str
+    timestamp: float
+    dependencies: List[str] = field(default_factory=list)
+    hash: str = ""
+    signature: str = ""
+
+    def payload(self) -> Dict[str, Any]:
+        return {
+            "evidence_id": self.evidence_id,
+            "evidence_type": self.evidence_type,
+            "value": self.value,
+            "source": self.source,
+            "timestamp": self.timestamp,
+            "dependencies": sorted(self.dependencies),
+        }
+
+    def compute_hash(self) -> str:
+        return canonical_hash(self.payload())
+
+    def sign(self, secret_key: bytes) -> "EvidenceObject":
+        self.hash = self.compute_hash()
+        self.signature = hmac_sign(secret_key, self.hash)
+        return self
+
+    def verify(self, secret_key: bytes) -> bool:
+        return self.hash == self.compute_hash() and hmac_verify(
+            secret_key, self.hash, self.signature
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            **self.payload(),
+            "hash": self.hash,
+            "signature": self.signature,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "EvidenceObject":
+        return cls(
+            evidence_id=data["evidence_id"],
+            evidence_type=data["evidence_type"],
+            value=dict(data.get("value", {})),
+            source=data["source"],
+            timestamp=float(data["timestamp"]),
+            dependencies=list(data.get("dependencies", [])),
+            hash=data.get("hash", ""),
+            signature=data.get("signature", ""),
+        )
+
+
+@dataclass
+class EvidenceAuthReport:
+    """Result of evaluating ``Auth(E)``."""
+
+    authenticated: bool
+    failures: List[str] = field(default_factory=list)
+    evidence_root: str = ""
+
+
+@dataclass
+class EvidenceBundle:
+    """Canonical bundle of signed deployment evidence."""
+
+    objects: List[EvidenceObject]
+
+    def sorted_objects(self) -> List[EvidenceObject]:
+        return sorted(self.objects, key=lambda obj: obj.evidence_id)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"objects": [obj.to_dict() for obj in self.sorted_objects()]}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "EvidenceBundle":
+        return cls([EvidenceObject.from_dict(obj) for obj in data.get("objects", [])])
+
+    def root(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def by_id(self) -> Dict[str, EvidenceObject]:
+        return {obj.evidence_id: obj for obj in self.objects}
+
+    def of_type(self, evidence_type: str) -> List[EvidenceObject]:
+        return [
+            obj
+            for obj in self.sorted_objects()
+            if obj.evidence_type == evidence_type
+        ]
+
+    def first_of_type(self, evidence_type: str) -> Optional[EvidenceObject]:
+        matches = self.of_type(evidence_type)
+        return matches[0] if matches else None
+
+    def authenticate(
+        self,
+        policy: Any,
+        request: Any,
+        secret_key: bytes,
+        now: Optional[float] = None,
+    ) -> EvidenceAuthReport:
+        failures: List[str] = []
+        objects_by_id: Dict[str, EvidenceObject] = {}
+
+        for obj in self.objects:
+            if obj.evidence_id in objects_by_id:
+                failures.append(f"EVIDENCE_DUPLICATE_ID:{obj.evidence_id}")
+            objects_by_id[obj.evidence_id] = obj
+            if not obj.hash:
+                failures.append(f"EVIDENCE_HASH_MISSING:{obj.evidence_id}")
+            elif obj.hash != obj.compute_hash():
+                failures.append(f"EVIDENCE_HASH_INVALID:{obj.evidence_id}")
+            if not obj.signature:
+                failures.append(f"EVIDENCE_SIGNATURE_MISSING:{obj.evidence_id}")
+            elif obj.hash == obj.compute_hash() and not obj.verify(secret_key):
+                failures.append(f"EVIDENCE_SIGNATURE_INVALID:{obj.evidence_id}")
+
+        for obj in self.objects:
+            for dependency in obj.dependencies:
+                if dependency not in objects_by_id:
+                    failures.append(
+                        f"EVIDENCE_DEPENDENCY_MISSING:{obj.evidence_id}:{dependency}"
+                    )
+
+        required_types = policy.required_evidence_types()
+        for evidence_type in required_types:
+            if not self.of_type(evidence_type):
+                failures.append(f"EVIDENCE_REQUIRED_MISSING:{evidence_type}")
+
+        if now is not None:
+            for evidence_type, max_age in policy.freshness_seconds.items():
+                for obj in self.of_type(evidence_type):
+                    if now - obj.timestamp > max_age:
+                        failures.append(f"EVIDENCE_STALE:{obj.evidence_id}")
+
+        failures.extend(_check_request_bindings(self, request))
+        failures.extend(_check_policy_predicates(self, policy, request))
+
+        return EvidenceAuthReport(
+            authenticated=not failures,
+            failures=failures,
+            evidence_root=self.root(),
+        )
+
+
+def signed_evidence(
+    evidence_id: str,
+    evidence_type: str,
+    value: Dict[str, Any],
+    source: str,
+    timestamp: float,
+    secret_key: bytes,
+    dependencies: Optional[Iterable[str]] = None,
+) -> EvidenceObject:
+    """Build and sign an evidence object for examples and tests."""
+    obj = EvidenceObject(
+        evidence_id=evidence_id,
+        evidence_type=evidence_type,
+        value=value,
+        source=source,
+        timestamp=timestamp,
+        dependencies=list(dependencies or []),
+    )
+    return obj.sign(secret_key)
+
+
+def _check_request_bindings(bundle: EvidenceBundle, request: Any) -> List[str]:
+    failures: List[str] = []
+    commit = bundle.first_of_type("commit_snapshot")
+    if commit and commit.value.get("commit_sha") != request.commit_sha:
+        failures.append("EVIDENCE_COMMIT_MISMATCH")
+
+    artifact = bundle.first_of_type("build_artifact")
+    if artifact and artifact.value.get("artifact_hash") != request.artifact_hash:
+        failures.append("EVIDENCE_ARTIFACT_MISMATCH")
+
+    env = bundle.first_of_type("environment_descriptor")
+    if env and env.value.get("environment") != request.environment:
+        failures.append("EVIDENCE_ENVIRONMENT_MISMATCH")
+
+    for obj in bundle.sorted_objects():
+        deployment_id = obj.value.get("deployment_id")
+        if deployment_id is not None and deployment_id != request.deployment_id:
+            failures.append(f"EVIDENCE_DEPLOYMENT_MISMATCH:{obj.evidence_id}")
+    return failures
+
+
+def _check_policy_predicates(
+    bundle: EvidenceBundle, policy: Any, request: Any
+) -> List[str]:
+    failures: List[str] = []
+    for predicate in policy.all_predicates():
+        name = predicate.name
+        params = predicate.params
+        if name in {"and", "or", "not"}:
+            continue
+        if name == "test_passed" and not _has_test_passed(bundle, params["suite"]):
+            failures.append(f"EVIDENCE_TEST_NOT_PASSED:{params['suite']}")
+        elif name == "vuln_count" and not _vuln_count_ok(bundle, params):
+            failures.append(
+                f"EVIDENCE_VULN_THRESHOLD_EXCEEDED:{params['severity']}"
+            )
+        elif name == "human_attested" and not _has_human_attestation(
+            bundle, params["role"], request.deployment_id
+        ):
+            failures.append(f"EVIDENCE_HUMAN_ATTESTATION_MISSING:{params['role']}")
+        elif name == "rollback_defined" and not _has_service_value(
+            bundle, "rollback_spec", params["service"], "rollback_plan"
+        ):
+            failures.append(f"EVIDENCE_ROLLBACK_MISSING:{params['service']}")
+        elif name == "canary_enabled" and not _has_canary(bundle, params["service"]):
+            failures.append(f"EVIDENCE_CANARY_MISSING:{params['service']}")
+        elif name == "environment_matches":
+            target = params["target"]
+            if target != policy.environment or target != request.environment:
+                failures.append(f"EVIDENCE_ENVIRONMENT_TARGET_MISMATCH:{target}")
+    return failures
+
+
+def _has_test_passed(bundle: EvidenceBundle, suite: str) -> bool:
+    return any(
+        obj.value.get("suite") == suite and obj.value.get("passed") is True
+        for obj in bundle.of_type("test_result")
+    )
+
+
+def _vuln_count_ok(bundle: EvidenceBundle, params: Dict[str, Any]) -> bool:
+    severity = params["severity"]
+    threshold = params["threshold"]
+    operator = params["operator"]
+    for obj in bundle.of_type("scan_report"):
+        counts = obj.value.get("vulnerabilities", {})
+        count = int(counts.get(severity, 0))
+        if operator == "<=" and count <= threshold:
+            return True
+        if operator == "==" and count == threshold:
+            return True
+    return False
+
+
+def _has_human_attestation(
+    bundle: EvidenceBundle, role: str, deployment_id: str
+) -> bool:
+    return any(
+        obj.value.get("role") == role
+        and obj.value.get("deployment_id") == deployment_id
+        and obj.value.get("approved") is True
+        for obj in bundle.of_type("human_attestation")
+    )
+
+
+def _has_service_value(
+    bundle: EvidenceBundle, evidence_type: str, service: str, value_key: str
+) -> bool:
+    return any(
+        obj.value.get("service") == service and bool(obj.value.get(value_key))
+        for obj in bundle.of_type(evidence_type)
+    )
+
+
+def _has_canary(bundle: EvidenceBundle, service: str) -> bool:
+    return any(
+        obj.value.get("service") == service
+        and bool(obj.value.get("canary_enabled"))
+        for obj in bundle.of_type("rollout_spec")
+    )

--- a/maatproof/ledger.py
+++ b/maatproof/ledger.py
@@ -1,0 +1,114 @@
+"""Append-only JSONL ledger for finalized deployment certificates."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+from .certificate import AcceptanceReport, CertificateChecker, DeploymentCertificate
+from .canonical import canonical_dumps
+
+
+@dataclass(frozen=True)
+class LedgerEntry:
+    """A finalized certificate record stored in JSONL."""
+
+    certificate_digest: str
+    policy_hash: str
+    evidence_root: str
+    proof_root: str
+    finality_result: Dict[str, Any]
+    environment: str
+    timestamp: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "certificate_digest": self.certificate_digest,
+            "policy_hash": self.policy_hash,
+            "evidence_root": self.evidence_root,
+            "proof_root": self.proof_root,
+            "finality_result": self.finality_result,
+            "environment": self.environment,
+            "timestamp": self.timestamp,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "LedgerEntry":
+        return cls(
+            certificate_digest=data["certificate_digest"],
+            policy_hash=data["policy_hash"],
+            evidence_root=data["evidence_root"],
+            proof_root=data["proof_root"],
+            finality_result=dict(data["finality_result"]),
+            environment=data["environment"],
+            timestamp=float(data["timestamp"]),
+        )
+
+
+class JsonlDeploymentLedger:
+    """Local append-only JSONL ledger suitable for Colab and tests."""
+
+    def __init__(self, path: Union[str, Path]) -> None:
+        self.path = Path(path)
+
+    def append(
+        self,
+        certificate: DeploymentCertificate,
+        report: AcceptanceReport,
+        timestamp: float,
+    ) -> LedgerEntry:
+        if not report.accepted:
+            raise ValueError("only accepted certificates may be appended")
+        entry = LedgerEntry(
+            certificate_digest=report.certificate_digest,
+            policy_hash=report.policy_root,
+            evidence_root=report.evidence_root,
+            proof_root=report.proof_root,
+            finality_result=report.to_dict(),
+            environment=certificate.request.environment,
+            timestamp=timestamp,
+        )
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(canonical_dumps(entry.to_dict()) + "\n")
+        return entry
+
+    def entries(self) -> List[LedgerEntry]:
+        if not self.path.exists():
+            return []
+        with self.path.open("r", encoding="utf-8") as handle:
+            return [
+                LedgerEntry.from_dict(json.loads(line))
+                for line in handle
+                if line.strip()
+            ]
+
+    def find(self, certificate_digest: str) -> Optional[LedgerEntry]:
+        for entry in self.entries():
+            if entry.certificate_digest == certificate_digest:
+                return entry
+        return None
+
+    def replay_verify(
+        self,
+        certificate: DeploymentCertificate,
+        checker: CertificateChecker,
+    ) -> AcceptanceReport:
+        report = checker.accept(certificate)
+        entry = self.find(certificate.digest())
+        if entry is None:
+            report.failures.append(_ledger_failure("LEDGER_ENTRY_MISSING"))
+            report.accepted = False
+            return report
+        if report.accepted and entry.certificate_digest != report.certificate_digest:
+            report.failures.append(_ledger_failure("LEDGER_DIGEST_MISMATCH"))
+            report.accepted = False
+        return report
+
+
+def _ledger_failure(code: str):
+    from .certificate import AcceptanceFailure
+
+    return AcceptanceFailure("Ledger", code)

--- a/maatproof/pod.py
+++ b/maatproof/pod.py
@@ -1,0 +1,182 @@
+"""Proof-of-Deploy validator attestations and quorum finality."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional
+
+from .canonical import hmac_sign, hmac_verify
+
+
+@dataclass
+class ValidatorAttestation:
+    """Signed validator decision over a canonical certificate digest."""
+
+    validator_id: str
+    decision: str
+    certificate_digest: str
+    timestamp: float
+    stake: float = 1.0
+    reason: str = ""
+    signature: str = ""
+
+    def payload(self) -> Dict[str, Any]:
+        return {
+            "validator_id": self.validator_id,
+            "decision": self.decision,
+            "certificate_digest": self.certificate_digest,
+            "timestamp": self.timestamp,
+            "stake": self.stake,
+            "reason": self.reason,
+        }
+
+    def sign(self, secret_key: bytes) -> "ValidatorAttestation":
+        self.signature = hmac_sign(secret_key, self.payload())
+        return self
+
+    def verify(self, secret_key: bytes) -> bool:
+        return hmac_verify(secret_key, self.payload(), self.signature)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {**self.payload(), "signature": self.signature}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ValidatorAttestation":
+        return cls(
+            validator_id=data["validator_id"],
+            decision=data["decision"],
+            certificate_digest=data["certificate_digest"],
+            timestamp=float(data["timestamp"]),
+            stake=float(data.get("stake", 1.0)),
+            reason=data.get("reason", ""),
+            signature=data.get("signature", ""),
+        )
+
+
+@dataclass(frozen=True)
+class QuorumRule:
+    """Parameterized finality rule for local validator replay."""
+
+    kind: str = "majority"
+    threshold: Optional[float] = None
+
+    @classmethod
+    def majority(cls) -> "QuorumRule":
+        return cls(kind="majority")
+
+    @classmethod
+    def supermajority(cls, fraction: float = 2 / 3) -> "QuorumRule":
+        return cls(kind="supermajority", threshold=fraction)
+
+    @classmethod
+    def weighted_threshold(cls, weight: float) -> "QuorumRule":
+        return cls(kind="weighted_threshold", threshold=weight)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"kind": self.kind, "threshold": self.threshold}
+
+
+@dataclass
+class FinalityReport:
+    """Result of evaluating ``Quorum(A)``."""
+
+    finalized: bool
+    failures: List[str] = field(default_factory=list)
+    accepted_weight: float = 0.0
+    total_weight: float = 0.0
+    accepted_validators: List[str] = field(default_factory=list)
+    disputed_validators: List[str] = field(default_factory=list)
+
+
+def quorum_finality(
+    attestations: Iterable[ValidatorAttestation],
+    certificate_digest: str,
+    validator_secret_keys: Dict[str, bytes],
+    rule: QuorumRule,
+) -> FinalityReport:
+    failures: List[str] = []
+    accepted_weight = 0.0
+    total_weight = 0.0
+    accepted_validators: List[str] = []
+    disputed_validators: List[str] = []
+    seen = set()
+
+    for attestation in attestations:
+        if attestation.validator_id in seen:
+            failures.append(f"QUORUM_DUPLICATE_VALIDATOR:{attestation.validator_id}")
+            continue
+        seen.add(attestation.validator_id)
+
+        if attestation.certificate_digest != certificate_digest:
+            failures.append(f"QUORUM_DIGEST_MISMATCH:{attestation.validator_id}")
+            continue
+        secret_key = validator_secret_keys.get(attestation.validator_id)
+        if secret_key is None:
+            failures.append(f"QUORUM_VALIDATOR_UNKNOWN:{attestation.validator_id}")
+            continue
+        if not attestation.signature or not attestation.verify(secret_key):
+            failures.append(f"QUORUM_SIGNATURE_INVALID:{attestation.validator_id}")
+            continue
+        if attestation.decision not in {"accept", "reject", "dispute"}:
+            failures.append(f"QUORUM_DECISION_INVALID:{attestation.validator_id}")
+            continue
+
+        total_weight += attestation.stake
+        if attestation.decision == "accept":
+            accepted_weight += attestation.stake
+            accepted_validators.append(attestation.validator_id)
+        elif attestation.decision == "dispute":
+            disputed_validators.append(attestation.validator_id)
+
+    if total_weight <= 0:
+        failures.append("QUORUM_NO_VALID_ATTESTATIONS")
+
+    threshold = _required_weight(rule, total_weight)
+    if accepted_weight < threshold:
+        failures.append("QUORUM_INSUFFICIENT_ACCEPT_WEIGHT")
+
+    return FinalityReport(
+        finalized=not failures,
+        failures=failures,
+        accepted_weight=accepted_weight,
+        total_weight=total_weight,
+        accepted_validators=accepted_validators,
+        disputed_validators=disputed_validators,
+    )
+
+
+def simulate_validators(
+    certificate: Any,
+    checker: Any,
+    validator_secret_keys: Dict[str, bytes],
+    timestamp: float,
+    stakes: Optional[Dict[str, float]] = None,
+) -> List[ValidatorAttestation]:
+    """Replay a certificate locally and sign validator decisions."""
+    digest = certificate.digest()
+    attestations: List[ValidatorAttestation] = []
+    for validator_id, secret_key in sorted(validator_secret_keys.items()):
+        report = checker.accept_without_quorum(certificate)
+        decision = "accept" if report.accepted else "reject"
+        reason = "" if report.accepted else ",".join(f.code for f in report.failures)
+        attestations.append(
+            ValidatorAttestation(
+                validator_id=validator_id,
+                decision=decision,
+                certificate_digest=digest,
+                timestamp=timestamp,
+                stake=(stakes or {}).get(validator_id, 1.0),
+                reason=reason,
+            ).sign(secret_key)
+        )
+    return attestations
+
+
+def _required_weight(rule: QuorumRule, total_weight: float) -> float:
+    if rule.kind == "majority":
+        return (total_weight / 2) + 1e-12
+    if rule.kind == "supermajority":
+        return total_weight * float(rule.threshold or (2 / 3))
+    if rule.kind == "weighted_threshold":
+        return float(rule.threshold or 0.0)
+    raise ValueError(f"unsupported quorum rule: {rule.kind}")

--- a/maatproof/policy.py
+++ b/maatproof/policy.py
@@ -1,0 +1,199 @@
+"""Deployment policy model and well-formedness checks for Proof-of-Deploy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List
+
+
+VALID_PREDICATES = {
+    "test_passed",
+    "vuln_count",
+    "human_attested",
+    "rollback_defined",
+    "canary_enabled",
+    "environment_matches",
+    "and",
+    "or",
+    "not",
+}
+
+DEFAULT_RULE_SET = "pod-v1"
+
+
+@dataclass(frozen=True)
+class PolicyPredicate:
+    """A typed deployment-policy predicate."""
+
+    name: str
+    params: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"name": self.name, "params": self.params}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "PolicyPredicate":
+        params = dict(data.get("params", {}))
+        if data.get("name") in {"and", "or"}:
+            params["children"] = [
+                cls.from_dict(child) for child in params.get("children", [])
+            ]
+        elif data.get("name") == "not" and isinstance(params.get("child"), dict):
+            params["child"] = cls.from_dict(params["child"])
+        return cls(name=data["name"], params=params)
+
+
+@dataclass
+class PolicyCheckReport:
+    """Result of evaluating ``WF(P)``."""
+
+    well_formed: bool
+    failures: List[str] = field(default_factory=list)
+
+
+@dataclass
+class DeploymentPolicy:
+    """Executable deployment contract used as the policy object ``P``."""
+
+    policy_id: str
+    version: int
+    environment: str
+    predicates: List[PolicyPredicate]
+    rule_set_id: str = DEFAULT_RULE_SET
+    freshness_seconds: Dict[str, float] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "policy_id": self.policy_id,
+            "version": self.version,
+            "environment": self.environment,
+            "rule_set_id": self.rule_set_id,
+            "freshness_seconds": dict(sorted(self.freshness_seconds.items())),
+            "predicates": [_predicate_to_dict(p) for p in self.predicates],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "DeploymentPolicy":
+        return cls(
+            policy_id=data["policy_id"],
+            version=int(data["version"]),
+            environment=data["environment"],
+            rule_set_id=data.get("rule_set_id", DEFAULT_RULE_SET),
+            freshness_seconds=dict(data.get("freshness_seconds", {})),
+            predicates=[
+                PolicyPredicate.from_dict(p) for p in data.get("predicates", [])
+            ],
+        )
+
+    def all_predicates(self) -> List[PolicyPredicate]:
+        return list(_walk_predicates(self.predicates))
+
+    def required_evidence_types(self) -> List[str]:
+        required = {"commit_snapshot", "build_artifact", "environment_descriptor"}
+        for predicate in self.all_predicates():
+            if predicate.name == "test_passed":
+                required.add("test_result")
+            elif predicate.name == "vuln_count":
+                required.add("scan_report")
+            elif predicate.name == "human_attested":
+                required.add("human_attestation")
+            elif predicate.name == "rollback_defined":
+                required.add("rollback_spec")
+            elif predicate.name == "canary_enabled":
+                required.add("rollout_spec")
+            elif predicate.name == "environment_matches":
+                required.add("environment_descriptor")
+        return sorted(required)
+
+    def human_attestation_required(self) -> bool:
+        return any(p.name == "human_attested" for p in self.all_predicates())
+
+    def well_formed(self) -> PolicyCheckReport:
+        failures: List[str] = []
+        if not self.policy_id:
+            failures.append("POLICY_ID_REQUIRED")
+        if self.version <= 0:
+            failures.append("POLICY_VERSION_INVALID")
+        if not self.environment:
+            failures.append("POLICY_ENVIRONMENT_REQUIRED")
+        if self.rule_set_id != DEFAULT_RULE_SET:
+            failures.append("POLICY_RULE_SET_UNSUPPORTED")
+        if not self.predicates:
+            failures.append("POLICY_PREDICATES_REQUIRED")
+
+        for predicate in self.all_predicates():
+            failures.extend(_validate_predicate(predicate))
+
+        environments = [
+            p.params.get("target")
+            for p in self.all_predicates()
+            if p.name == "environment_matches"
+        ]
+        if environments and self.environment not in environments:
+            failures.append("POLICY_ENVIRONMENT_CONTRADICTION")
+
+        for evidence_type, seconds in self.freshness_seconds.items():
+            if not isinstance(evidence_type, str) or not evidence_type:
+                failures.append("POLICY_FRESHNESS_TYPE_INVALID")
+            if not isinstance(seconds, (int, float)) or seconds <= 0:
+                failures.append(f"POLICY_FRESHNESS_INVALID:{evidence_type}")
+
+        return PolicyCheckReport(well_formed=not failures, failures=failures)
+
+
+def _predicate_to_dict(predicate: PolicyPredicate) -> Dict[str, Any]:
+    params = {}
+    for key, value in predicate.params.items():
+        if isinstance(value, PolicyPredicate):
+            params[key] = _predicate_to_dict(value)
+        elif isinstance(value, list) and value and isinstance(value[0], PolicyPredicate):
+            params[key] = [_predicate_to_dict(item) for item in value]
+        else:
+            params[key] = value
+    return {"name": predicate.name, "params": params}
+
+
+def _walk_predicates(predicates: Iterable[PolicyPredicate]) -> Iterable[PolicyPredicate]:
+    for predicate in predicates:
+        yield predicate
+        if predicate.name in {"and", "or"}:
+            yield from _walk_predicates(predicate.params.get("children", []))
+        elif predicate.name == "not" and isinstance(
+            predicate.params.get("child"), PolicyPredicate
+        ):
+            yield from _walk_predicates([predicate.params["child"]])
+
+
+def _validate_predicate(predicate: PolicyPredicate) -> List[str]:
+    failures: List[str] = []
+    if predicate.name not in VALID_PREDICATES:
+        return [f"POLICY_PREDICATE_UNKNOWN:{predicate.name}"]
+
+    params = predicate.params
+    if predicate.name == "test_passed":
+        if not isinstance(params.get("suite"), str) or not params["suite"]:
+            failures.append("POLICY_TEST_SUITE_INVALID")
+    elif predicate.name == "vuln_count":
+        if not isinstance(params.get("severity"), str) or not params["severity"]:
+            failures.append("POLICY_VULN_SEVERITY_INVALID")
+        if params.get("operator") not in {"<=", "=="}:
+            failures.append("POLICY_VULN_OPERATOR_INVALID")
+        if not isinstance(params.get("threshold"), int) or params["threshold"] < 0:
+            failures.append("POLICY_VULN_THRESHOLD_INVALID")
+    elif predicate.name == "human_attested":
+        if not isinstance(params.get("role"), str) or not params["role"]:
+            failures.append("POLICY_HUMAN_ROLE_INVALID")
+    elif predicate.name in {"rollback_defined", "canary_enabled"}:
+        if not isinstance(params.get("service"), str) or not params["service"]:
+            failures.append(f"POLICY_{predicate.name.upper()}_SERVICE_INVALID")
+    elif predicate.name == "environment_matches":
+        if not isinstance(params.get("target"), str) or not params["target"]:
+            failures.append("POLICY_ENVIRONMENT_TARGET_INVALID")
+    elif predicate.name in {"and", "or"}:
+        children = params.get("children")
+        if not isinstance(children, list) or not children:
+            failures.append(f"POLICY_{predicate.name.upper()}_CHILDREN_REQUIRED")
+    elif predicate.name == "not":
+        if not isinstance(params.get("child"), PolicyPredicate):
+            failures.append("POLICY_NOT_CHILD_REQUIRED")
+    return failures

--- a/maatproof/vrp.py
+++ b/maatproof/vrp.py
@@ -1,0 +1,184 @@
+"""Verifiable Reasoning Protocol derivations for Proof-of-Deploy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Set
+
+from .evidence import EvidenceBundle
+
+
+VALID_RULES = {
+    "TEST_PASS",
+    "VULN_OK",
+    "SIGNATURE_VALID",
+    "EVIDENCE_BOUND",
+    "ENVIRONMENT_MATCH",
+    "ROLLBACK_READY",
+    "HUMAN_ATTESTED",
+    "POLICY_SATISFIED",
+    "DEPLOY_AUTH",
+}
+
+
+@dataclass
+class ProofStep:
+    """A typed admissible proof step in the derivation ``pi``."""
+
+    step_id: str
+    rule: str
+    conclusion: str
+    evidence_refs: List[str] = field(default_factory=list)
+    premises: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "step_id": self.step_id,
+            "rule": self.rule,
+            "conclusion": self.conclusion,
+            "evidence_refs": sorted(self.evidence_refs),
+            "premises": list(self.premises),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ProofStep":
+        return cls(
+            step_id=data["step_id"],
+            rule=data["rule"],
+            conclusion=data["conclusion"],
+            evidence_refs=list(data.get("evidence_refs", [])),
+            premises=list(data.get("premises", [])),
+        )
+
+
+@dataclass
+class ProofDerivation:
+    """Machine-checkable derivation used by ``CheckR(pi, P, E)``."""
+
+    steps: List[ProofStep]
+    final_conclusion: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "steps": [step.to_dict() for step in self.steps],
+            "final_conclusion": self.final_conclusion,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ProofDerivation":
+        return cls(
+            steps=[ProofStep.from_dict(step) for step in data.get("steps", [])],
+            final_conclusion=data["final_conclusion"],
+        )
+
+
+@dataclass
+class VrpCheckReport:
+    """Result of evaluating ``CheckR(pi, P, E)``."""
+
+    valid: bool
+    failures: List[str] = field(default_factory=list)
+    proof_root: str = ""
+
+
+def check_derivation(
+    derivation: ProofDerivation,
+    policy: Any,
+    evidence: EvidenceBundle,
+    request: Any,
+) -> VrpCheckReport:
+    failures: List[str] = []
+    known_steps: Set[str] = set()
+    evidence_by_id = evidence.by_id()
+
+    if not derivation.steps:
+        failures.append("VRP_STEPS_REQUIRED")
+
+    for step in derivation.steps:
+        if not step.step_id:
+            failures.append("VRP_STEP_ID_REQUIRED")
+        if step.step_id in known_steps:
+            failures.append(f"VRP_STEP_DUPLICATE:{step.step_id}")
+        known_steps.add(step.step_id)
+        if step.rule not in VALID_RULES:
+            failures.append(f"VRP_RULE_UNKNOWN:{step.rule}")
+        for premise in step.premises:
+            if premise not in known_steps:
+                failures.append(f"VRP_PREMISE_MISSING:{step.step_id}:{premise}")
+        for evidence_ref in step.evidence_refs:
+            if evidence_ref not in evidence_by_id:
+                failures.append(
+                    f"VRP_EVIDENCE_REF_MISSING:{step.step_id}:{evidence_ref}"
+                )
+        failures.extend(_check_rule_semantics(step, policy, evidence, request))
+
+    expected_final = f"deploy_authorized:{request.deployment_id}"
+    if derivation.final_conclusion != expected_final:
+        failures.append("VRP_FINAL_CONCLUSION_MISMATCH")
+    if not derivation.steps or derivation.steps[-1].conclusion != expected_final:
+        failures.append("VRP_FINAL_STEP_MISMATCH")
+
+    from .canonical import canonical_hash
+
+    return VrpCheckReport(
+        valid=not failures,
+        failures=failures,
+        proof_root=canonical_hash(derivation.to_dict()),
+    )
+
+
+def _check_rule_semantics(
+    step: ProofStep,
+    policy: Any,
+    evidence: EvidenceBundle,
+    request: Any,
+) -> List[str]:
+    failures: List[str] = []
+    refs = [evidence.by_id()[ref] for ref in step.evidence_refs if ref in evidence.by_id()]
+
+    if step.rule == "TEST_PASS":
+        if not any(obj.evidence_type == "test_result" and obj.value.get("passed") for obj in refs):
+            failures.append(f"VRP_TEST_PASS_UNSUPPORTED:{step.step_id}")
+    elif step.rule == "VULN_OK":
+        if not any(obj.evidence_type == "scan_report" for obj in refs):
+            failures.append(f"VRP_VULN_OK_UNSUPPORTED:{step.step_id}")
+    elif step.rule == "SIGNATURE_VALID":
+        if not refs:
+            failures.append(f"VRP_SIGNATURE_REF_REQUIRED:{step.step_id}")
+    elif step.rule == "EVIDENCE_BOUND":
+        if not refs:
+            failures.append(f"VRP_EVIDENCE_BOUND_REF_REQUIRED:{step.step_id}")
+        for obj in refs:
+            deployment_id = obj.value.get("deployment_id")
+            if deployment_id is not None and deployment_id != request.deployment_id:
+                failures.append(f"VRP_EVIDENCE_NOT_BOUND:{step.step_id}")
+    elif step.rule == "ENVIRONMENT_MATCH":
+        if policy.environment != request.environment:
+            failures.append(f"VRP_ENVIRONMENT_POLICY_MISMATCH:{step.step_id}")
+        if not any(
+            obj.evidence_type == "environment_descriptor"
+            and obj.value.get("environment") == request.environment
+            for obj in refs
+        ):
+            failures.append(f"VRP_ENVIRONMENT_REF_MISSING:{step.step_id}")
+    elif step.rule == "ROLLBACK_READY":
+        if not any(obj.evidence_type == "rollback_spec" for obj in refs):
+            failures.append(f"VRP_ROLLBACK_REF_MISSING:{step.step_id}")
+    elif step.rule == "HUMAN_ATTESTED":
+        if policy.human_attestation_required() and not any(
+            obj.evidence_type == "human_attestation"
+            and obj.value.get("approved") is True
+            for obj in refs
+        ):
+            failures.append(f"VRP_HUMAN_ATTESTATION_REF_MISSING:{step.step_id}")
+    elif step.rule == "POLICY_SATISFIED":
+        if not step.premises:
+            failures.append(f"VRP_POLICY_PREMISES_REQUIRED:{step.step_id}")
+        if step.conclusion != "policy_satisfied":
+            failures.append(f"VRP_POLICY_CONCLUSION_INVALID:{step.step_id}")
+    elif step.rule == "DEPLOY_AUTH":
+        if "policy_satisfied" not in step.conclusion and step.conclusion != f"deploy_authorized:{request.deployment_id}":
+            failures.append(f"VRP_DEPLOY_AUTH_CONCLUSION_INVALID:{step.step_id}")
+        if not step.premises:
+            failures.append(f"VRP_DEPLOY_AUTH_PREMISE_REQUIRED:{step.step_id}")
+    return failures

--- a/tests/test_proof_of_deploy.py
+++ b/tests/test_proof_of_deploy.py
@@ -1,0 +1,362 @@
+"""Tests for the Python Proof-of-Deploy reference implementation."""
+
+from pathlib import Path
+
+import pytest
+
+from maatproof.avm import DeploymentTrace, ToolTrace
+from maatproof.certificate import (
+    CertificateChecker,
+    DeploymentCertificate,
+    DeploymentRequest,
+)
+from maatproof.evidence import EvidenceBundle, signed_evidence
+from maatproof.ledger import JsonlDeploymentLedger
+from maatproof.pod import QuorumRule, ValidatorAttestation, simulate_validators
+from maatproof.policy import DeploymentPolicy, PolicyPredicate
+from maatproof.vrp import ProofDerivation, ProofStep
+
+
+EVIDENCE_SECRET = b"evidence-secret"
+VALIDATORS = {
+    "validator-a": b"validator-a-secret",
+    "validator-b": b"validator-b-secret",
+    "validator-c": b"validator-c-secret",
+}
+NOW = 1_700_000_100.0
+
+
+def _request(environment: str = "production") -> DeploymentRequest:
+    return DeploymentRequest(
+        deployment_id="deploy-123",
+        service="checkout",
+        environment=environment,
+        commit_sha="abc123",
+        artifact_hash="sha256:artifact",
+        requested_by="agent:planner",
+    )
+
+
+def _policy(environment: str = "production") -> DeploymentPolicy:
+    return DeploymentPolicy(
+        policy_id="checkout-prod",
+        version=1,
+        environment=environment,
+        freshness_seconds={"human_attestation": 3600, "scan_report": 3600},
+        predicates=[
+            PolicyPredicate("test_passed", {"suite": "unit"}),
+            PolicyPredicate(
+                "vuln_count",
+                {"severity": "critical", "operator": "<=", "threshold": 0},
+            ),
+            PolicyPredicate("environment_matches", {"target": environment}),
+            PolicyPredicate("rollback_defined", {"service": "checkout"}),
+            PolicyPredicate("human_attested", {"role": "release-manager"}),
+        ],
+    )
+
+
+def _evidence(
+    request: DeploymentRequest,
+    *,
+    timestamp: float = NOW,
+    include_scan: bool = True,
+    human_timestamp: float = NOW,
+) -> EvidenceBundle:
+    objects = [
+        signed_evidence(
+            "commit",
+            "commit_snapshot",
+            {
+                "deployment_id": request.deployment_id,
+                "commit_sha": request.commit_sha,
+            },
+            "git",
+            timestamp,
+            EVIDENCE_SECRET,
+        ),
+        signed_evidence(
+            "artifact",
+            "build_artifact",
+            {
+                "deployment_id": request.deployment_id,
+                "artifact_hash": request.artifact_hash,
+            },
+            "builder",
+            timestamp,
+            EVIDENCE_SECRET,
+            dependencies=["commit"],
+        ),
+        signed_evidence(
+            "test",
+            "test_result",
+            {"deployment_id": request.deployment_id, "suite": "unit", "passed": True},
+            "pytest",
+            timestamp,
+            EVIDENCE_SECRET,
+            dependencies=["artifact"],
+        ),
+        signed_evidence(
+            "env",
+            "environment_descriptor",
+            {
+                "deployment_id": request.deployment_id,
+                "environment": request.environment,
+            },
+            "cluster",
+            timestamp,
+            EVIDENCE_SECRET,
+        ),
+        signed_evidence(
+            "rollback",
+            "rollback_spec",
+            {
+                "deployment_id": request.deployment_id,
+                "service": request.service,
+                "rollback_plan": "restore previous image",
+            },
+            "deploy-plan",
+            timestamp,
+            EVIDENCE_SECRET,
+        ),
+        signed_evidence(
+            "human",
+            "human_attestation",
+            {
+                "deployment_id": request.deployment_id,
+                "role": "release-manager",
+                "approved": True,
+            },
+            "approvals",
+            human_timestamp,
+            EVIDENCE_SECRET,
+        ),
+    ]
+    if include_scan:
+        objects.append(
+            signed_evidence(
+                "scan",
+                "scan_report",
+                {
+                    "deployment_id": request.deployment_id,
+                    "vulnerabilities": {"critical": 0, "high": 1},
+                },
+                "scanner",
+                timestamp,
+                EVIDENCE_SECRET,
+                dependencies=["artifact"],
+            )
+        )
+    return EvidenceBundle(objects)
+
+
+def _proof(request: DeploymentRequest, *, final: str = "") -> ProofDerivation:
+    return ProofDerivation(
+        final_conclusion=final or f"deploy_authorized:{request.deployment_id}",
+        steps=[
+            ProofStep("test-pass", "TEST_PASS", "test_passed:unit", ["test"]),
+            ProofStep("scan-ok", "VULN_OK", "vuln_count:critical<=0", ["scan"]),
+            ProofStep("env-ok", "ENVIRONMENT_MATCH", "environment_matches", ["env"]),
+            ProofStep("rollback-ok", "ROLLBACK_READY", "rollback_defined", ["rollback"]),
+            ProofStep(
+                "human-ok",
+                "HUMAN_ATTESTED",
+                "human_attested:release-manager",
+                ["human"],
+            ),
+            ProofStep(
+                "policy",
+                "POLICY_SATISFIED",
+                "policy_satisfied",
+                premises=[
+                    "test-pass",
+                    "scan-ok",
+                    "env-ok",
+                    "rollback-ok",
+                    "human-ok",
+                ],
+            ),
+            ProofStep(
+                "deploy",
+                "DEPLOY_AUTH",
+                f"deploy_authorized:{request.deployment_id}",
+                premises=["policy"],
+            ),
+        ],
+    )
+
+
+def _certificate(include_scan: bool = True) -> DeploymentCertificate:
+    request = _request()
+    return DeploymentCertificate(
+        request=request,
+        policy=_policy(),
+        evidence=_evidence(request, include_scan=include_scan),
+        proof=_proof(request),
+    )
+
+
+def _accepted_certificate() -> DeploymentCertificate:
+    certificate = _certificate()
+    checker = CertificateChecker(EVIDENCE_SECRET, now=NOW)
+    certificate.attestations = simulate_validators(
+        certificate, checker, VALIDATORS, timestamp=NOW
+    )
+    return certificate
+
+
+def test_valid_certificate_requires_all_four_acceptance_terms():
+    certificate = _accepted_certificate()
+    checker = CertificateChecker(EVIDENCE_SECRET, VALIDATORS, now=NOW)
+
+    report = checker.accept(certificate)
+
+    assert report.accepted
+    assert report.wf_policy
+    assert report.auth_evidence
+    assert report.check_proof
+    assert report.quorum
+
+
+def test_missing_scan_evidence_is_structured_rejection():
+    certificate = _certificate(include_scan=False)
+    checker = CertificateChecker(EVIDENCE_SECRET, VALIDATORS, now=NOW)
+
+    report = checker.accept(certificate)
+
+    assert not report.accepted
+    codes = {failure.code for failure in report.failures}
+    assert "EVIDENCE_REQUIRED_MISSING:scan_report" in codes
+    assert "VRP_EVIDENCE_REF_MISSING:scan-ok:scan" in codes
+
+
+def test_stale_human_attestation_rejects_when_policy_requires_freshness():
+    request = _request()
+    certificate = DeploymentCertificate(
+        request=request,
+        policy=_policy(),
+        evidence=_evidence(request, human_timestamp=NOW - 7200),
+        proof=_proof(request),
+    )
+    checker = CertificateChecker(EVIDENCE_SECRET, VALIDATORS, now=NOW)
+
+    report = checker.accept(certificate)
+
+    assert not report.accepted
+    assert "EVIDENCE_STALE:human" in {failure.code for failure in report.failures}
+
+
+def test_wrong_environment_binding_rejects():
+    request = _request("staging")
+    certificate = DeploymentCertificate(
+        request=request,
+        policy=_policy("production"),
+        evidence=_evidence(request),
+        proof=_proof(request),
+    )
+    checker = CertificateChecker(EVIDENCE_SECRET, VALIDATORS, now=NOW)
+
+    report = checker.accept(certificate)
+
+    assert not report.accepted
+    codes = {failure.code for failure in report.failures}
+    assert "EVIDENCE_ENVIRONMENT_TARGET_MISMATCH:production" in codes
+    assert "VRP_ENVIRONMENT_POLICY_MISMATCH:env-ok" in codes
+
+
+def test_invalid_derivation_step_rejects():
+    certificate = _certificate()
+    certificate.proof.steps[0].rule = "TRUST_ME"
+    checker = CertificateChecker(EVIDENCE_SECRET, VALIDATORS, now=NOW)
+
+    report = checker.accept(certificate)
+
+    assert not report.accepted
+    assert "VRP_RULE_UNKNOWN:TRUST_ME" in {failure.code for failure in report.failures}
+
+
+def test_insufficient_validator_quorum_rejects():
+    certificate = _certificate()
+    digest = certificate.digest()
+    certificate.attestations = [
+        ValidatorAttestation("validator-a", "accept", digest, NOW).sign(
+            VALIDATORS["validator-a"]
+        ),
+        ValidatorAttestation("validator-b", "reject", digest, NOW).sign(
+            VALIDATORS["validator-b"]
+        ),
+    ]
+    checker = CertificateChecker(EVIDENCE_SECRET, VALIDATORS, now=NOW)
+
+    report = checker.accept(certificate)
+
+    assert not report.accepted
+    assert "QUORUM_INSUFFICIENT_ACCEPT_WEIGHT" in {
+        failure.code for failure in report.failures
+    }
+
+
+def test_canonical_evidence_root_is_order_independent():
+    certificate = _certificate()
+    reversed_bundle = EvidenceBundle(list(reversed(certificate.evidence.objects)))
+
+    assert certificate.evidence.root() == reversed_bundle.root()
+
+
+def test_unsigned_or_tampered_evidence_rejects():
+    certificate = _certificate()
+    certificate.evidence.objects[0].value["commit_sha"] = "tampered"
+    checker = CertificateChecker(EVIDENCE_SECRET, VALIDATORS, now=NOW)
+
+    report = checker.accept(certificate)
+
+    assert not report.accepted
+    codes = {failure.code for failure in report.failures}
+    assert "EVIDENCE_HASH_INVALID:commit" in codes
+    assert "EVIDENCE_COMMIT_MISMATCH" in codes
+
+
+def test_jsonl_ledger_appends_and_replays_finalized_certificate(tmp_path: Path):
+    certificate = _accepted_certificate()
+    checker = CertificateChecker(EVIDENCE_SECRET, VALIDATORS, now=NOW)
+    report = checker.accept(certificate)
+    ledger = JsonlDeploymentLedger(tmp_path / "deployments.jsonl")
+
+    entry = ledger.append(certificate, report, timestamp=NOW)
+    replay = ledger.replay_verify(certificate, checker)
+
+    assert entry.certificate_digest == certificate.digest()
+    assert replay.accepted
+
+
+def test_avm_trace_can_emit_signed_evidence_bundle():
+    trace = DeploymentTrace(
+        deployment_id="deploy-123",
+        tools=[
+            ToolTrace(
+                tool_name="pytest",
+                output_type="test_result",
+                output={"suite": "unit", "passed": True},
+                timestamp=NOW,
+            )
+        ],
+    )
+
+    bundle = trace.to_evidence_bundle(EVIDENCE_SECRET)
+
+    assert bundle.objects[0].evidence_type == "test_result"
+    assert bundle.objects[0].verify(EVIDENCE_SECRET)
+
+
+def test_policy_well_formed_rejects_unknown_predicate():
+    policy = DeploymentPolicy(
+        policy_id="bad",
+        version=1,
+        environment="production",
+        predicates=[PolicyPredicate("trust_me", {})],
+    )
+
+    report = policy.well_formed()
+
+    assert not report.well_formed
+    assert "POLICY_PREDICATE_UNKNOWN:trust_me" in report.failures


### PR DESCRIPTION
This adds an executable Python reference implementation for the Proof-of-Deploy certificate architecture so reviewers and users can exercise the paper's `C = <P, E, pi, A>` model locally and in Google Colab.

## Summary

- Adds canonical serialization/HMAC helpers, signed evidence bundles, deployment policies, VRP derivations, validator quorum checks, certificate acceptance, AVM boundary traces, and a JSONL ledger.
- Exposes the new Proof-of-Deploy API from `maatproof` while preserving the existing reasoning proof and pipeline APIs.
- Adds a Colab notebook that demonstrates a valid finalized deployment plus structured rejection cases for missing scan evidence, stale human attestation, wrong environment binding, invalid derivation, and insufficient quorum.
- Updates README, architecture docs, and roadmap to describe the Python prototype and how it maps to `WF(P)`, `Auth(E)`, `CheckR(pi, P, E)`, and `Quorum(A)`.

## Notes for reviewers

The prototype intentionally uses HMAC-SHA256 to stay dependency-free for tests and Colab. Production-grade Ed25519 or post-quantum signatures can be added later as adapters without changing the certificate validity rule.

## Validation

- `python -m pytest tests\ -v` -> 93 passed
- Colab notebook JSON/import sanity check passed
- Notebook code cells execute successfully