### PR TITLE
Restore README white paper link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ For a non-technical reader: this repo is like a black box recorder for deploymen
 
 Modern CI/CD logs tell you what happened. MaatProof aims to prove why a deployment was allowed.
 
+The formal motivation and broader protocol argument are developed in the [MaatProof White Paper](https://www.overleaf.com/read/hvsvqyvzfmhf#89e3b9).
+
 The core object is a deployment certificate:
 
 ```text


### PR DESCRIPTION
This restores the MaatProof White Paper link in the README so the formal research motivation remains easy to find.

## Summary

- Adds the whitepaper link back under `Research perspective`.
- Frames the link as the source for the broader protocol argument and formal motivation.

## Validation

- Documentation-only change.