### PR TITLE
fix: update Colab install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The design separates research concerns cleanly:
 
 ## Try it in Google Colab
 
-Open [`examples/proof_of_deploy_colab.ipynb`](examples/proof_of_deploy_colab.ipynb) to run a complete proof-of-deploy flow.
+Open [`examples/proof_of_deploy_colab.ipynb`](examples/proof_of_deploy_colab.ipynb) to run a complete proof-of-deploy flow. The notebook installs the Python package from `PYTHON/`, where the package metadata lives.
 
 The notebook demonstrates:
 

--- a/examples/proof_of_deploy_colab.ipynb
+++ b/examples/proof_of_deploy_colab.ipynb
@@ -15,13 +15,26 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# In Google Colab, run this after cloning the repository:\n",
-        "# !git clone https://github.com/dngoins/MaatProof.git\n",
-        "# %cd MaatProof\n",
-        "# !pip install -e .\n",
+        "# In Google Colab, run this cell once to clone the repo and install the Python package.\n",
+        "# In a local checkout, it also works from either the repository root or the PYTHON directory.\n",
+        "from pathlib import Path\n",
+        "import os\n",
+        "import subprocess\n",
         "\n",
-        "# In a local checkout, install with:\n",
-        "# !pip install -e ."
+        "cwd = Path.cwd()\n",
+        "if (cwd / 'pyproject.toml').exists() and (cwd / 'maatproof').exists():\n",
+        "    python_project = cwd\n",
+        "elif (cwd / 'PYTHON' / 'pyproject.toml').exists():\n",
+        "    python_project = cwd / 'PYTHON'\n",
+        "else:\n",
+        "    repo = Path('/content/MaatProof')\n",
+        "    python_project = repo / 'PYTHON'\n",
+        "    if not (python_project / 'pyproject.toml').exists():\n",
+        "        subprocess.run(['git', 'clone', 'https://github.com/dngoins/MaatProof.git', str(repo)], check=True)\n",
+        "\n",
+        "os.chdir(python_project)\n",
+        "print(f'Installing maatproof from {python_project}')\n",
+        "%pip install -e ."
       ]
     },
     {


### PR DESCRIPTION
Colab currently tries to run `pip install -e .` from the repository root, but the Python package metadata lives in `PYTHON/`. That makes the sample fail because pip cannot find `pyproject.toml` at the root.

## Summary
- Updates the notebook install cell to detect the actual Python project directory and install from `PYTHON/` when run from the repo root.
- Keeps the cell usable from Colab, the repository root, or the `PYTHON/` directory.
- Notes in the README that the notebook installs the package from `PYTHON/`.

## Validation
- `python -c "import json; json.load(open(r'examples\\proof_of_deploy_colab.ipynb', encoding='utf-8')); print('notebook json ok')"`
- `Set-Location PYTHON; python -m pytest tests -v`